### PR TITLE
Look at DeliveryResult for tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 log = "0.3"
 
 [dependencies.hyper]
-git = "https://github.com/DarrenTsung/hyper.git"
+git = "https://github.com/jwilm/hyper.git"
 branch = "better-errors"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 log = "0.3"
 
 [dependencies.hyper]
-git = "https://github.com/jwilm/hyper.git"
+git = "https://github.com/DarrenTsung/hyper.git"
 branch = "better-errors"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,15 @@
 pub extern crate hyper;
 #[macro_use] extern crate log;
 
-use std::io;
-use std::time::{Instant, Duration};
 use std::fmt;
+use std::io;
 use std::mem;
+use std::time::{Instant, Duration};
 
-use hyper::client::{Request, Handler, Response, DefaultTransport};
 use hyper::{Next, Encoder, Decoder};
-use hyper::method::Method;
+use hyper::client::{Request, Handler, Response, DefaultTransport};
 use hyper::Headers;
+use hyper::method::Method;
 
 pub mod pool;
 
@@ -306,12 +306,12 @@ impl Deliverable for ::std::sync::mpsc::Sender<DeliveryResult> {
 mod tests {
     extern crate env_logger;
 
-    use std::time::Duration;
     use std::sync::mpsc;
+    use std::time::Duration;
 
+    use hyper::{Headers, Url};
     use hyper::client::Client;
     use hyper::method::Method;
-    use hyper::{Headers, Url};
 
     use super::{DeliveryResult, Transaction};
 
@@ -339,7 +339,12 @@ mod tests {
 
         client.request(url, transaction).unwrap();
 
-        rx.recv().unwrap();
+        let delivery_result = rx.recv().unwrap();
+        match delivery_result {
+            DeliveryResult::Response { .. } => (), // ok
+            _ => panic!("Delivery result is not as expected: {:?}", delivery_result),
+        }
+
         client.close();
     }
 
@@ -373,7 +378,11 @@ mod tests {
 
             // Make sure they're all done
             for _ in 0..concurrent {
-                rx.recv().unwrap();
+                let delivery_result = rx.recv().unwrap();
+                match delivery_result {
+                    DeliveryResult::Response { .. } => (), // ok
+                    _ => panic!("Delivery result is not as expected: {:?}", delivery_result),
+                }
             }
 
             // Now make requests somewhere else. Since the keep-alive is five
@@ -391,7 +400,11 @@ mod tests {
             }
 
             for _ in 0..concurrent {
-                rx.recv().unwrap();
+                let delivery_result = rx.recv().unwrap();
+                match delivery_result {
+                    DeliveryResult::Response { .. } => (), // ok
+                    _ => panic!("Delivery result is not as expected: {:?}", delivery_result),
+                }
             }
         }
 

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -9,9 +9,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use hyper::client::{Request, Handler, Response, DefaultTransport, ClientError};
-use hyper::{Next, Encoder, Decoder};
 use hyper;
+use hyper::{Next, Encoder, Decoder};
+use hyper::client::{Request, Handler, Response, DefaultTransport, ClientError};
 use hyper::Url;
 
 use super::{Transaction, Deliverable};
@@ -405,14 +405,14 @@ impl<D: Deliverable> Pool<D> {
 #[cfg(test)]
 mod tests {
     use std::sync::mpsc;
-    use std::sync::atomic::{Ordering, AtomicUsize};
     use std::sync::Arc;
+    use std::sync::atomic::{Ordering, AtomicUsize};
 
-    use hyper::Url;
     use hyper::method::Method;
+    use hyper::Url;
 
-    use super::{Config, Pool, Error};
     use ::{Transaction, Deliverable, DeliveryResult};
+    use super::{Config, Pool, Error};
 
     #[derive(Clone)]
     struct CompletionCounter(Arc<AtomicUsize>);


### PR DESCRIPTION
Currently we aren't looking at the actual delivery result for the tests. I believe it should be StatusCode::Ok. Right now the tests fail because jwilm/hyper is at a broken state due to ssl handshake errors that should be resolved when this PR is merged (https://github.com/jwilm/hyper/pull/2).