### PR TITLE
Remove hyper fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 log = "0.4"
-hyper = { git = "https://github.com/DarrenTsung/hyper", branch = "fix-socket-thrash" }
+hyper = { git = "https://github.com/hyperium/hyper", branch = "client-continue-lost-connects" }
 native-tls = "0.1"
 hyper-tls = "0.2"
 futures = "0.1"
@@ -23,4 +23,4 @@ ipnet = "1.2"
 regex = "1.0"
 
 [replace]
-"hyper:0.12.3" = { git = "https://github.com/DarrenTsung/hyper", branch = "fix-socket-thrash" }
+"hyper:0.12.3" = { git = "https://github.com/hyperium/hyper", branch = "client-continue-lost-connects" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 log = "0.4"
-hyper = { git = "https://github.com/hyperium/hyper", branch = "client-continue-lost-connects" }
+hyper = "0.12"
 native-tls = "0.1"
 hyper-tls = "0.2"
 futures = "0.1"
@@ -21,6 +21,3 @@ env_logger = "0.5"
 lazy_static = "1.0"
 ipnet = "1.2"
 regex = "1.0"
-
-[replace]
-"hyper:0.12.3" = { git = "https://github.com/hyperium/hyper", branch = "client-continue-lost-connects" }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -96,7 +96,6 @@ impl<D: Deliverable> Executor<D> {
                 let client = hyper::Client::builder()
                     .keep_alive(true)
                     .keep_alive_timeout(Some(keep_alive_timeout))
-                    .avoid_socket_thrash(true)
                     .build(connector);
 
                 let executor = Executor {


### PR DESCRIPTION
The fix was merged upstream: https://github.com/hyperium/hyper/pull/1585, and a new release (hyper 0.12.4) was released.