### PR TITLE
Monitor transaction counts

### DIFF
--- a/src/executor/transaction_counter.rs
+++ b/src/executor/transaction_counter.rs
@@ -1,0 +1,26 @@
+use raii_counter::WeakCounter;
+
+pub struct TransactionCounter {
+    transaction_counter: WeakCounter,
+    worker_counter: WeakCounter,
+}
+
+impl TransactionCounter {
+    pub(crate) fn new(
+        transaction_counter: WeakCounter,
+        worker_counter: WeakCounter
+    ) -> TransactionCounter {
+        TransactionCounter { transaction_counter, worker_counter }
+    }
+
+    /// Get the count of transactions
+    pub fn count(&self) -> usize {
+        self.transaction_counter.count()
+    }
+
+    /// Checks that the Worker is still alive
+    /// The strong counter is held by the Worker
+    pub fn is_valid(&self) -> bool {
+        self.worker_counter.count() > 0
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,9 @@ mod error;
 mod executor;
 mod pool;
 mod transaction;
+mod util;
 
+pub use executor::TransactionCounter;
 pub use deliverable::Deliverable;
 pub use transaction::{Transaction, DeliveryResult};
 pub use pool::Pool;

--- a/src/pool/builder.rs
+++ b/src/pool/builder.rs
@@ -1,0 +1,40 @@
+use std::marker::PhantomData;
+use std::sync::{Arc, RwLock};
+use deliverable::Deliverable;
+
+use super::Pool;
+use config::Config;
+use error::SpawnError;
+use executor::TransactionCounter;
+
+pub struct PoolBuilder<D: Deliverable> {
+    pub(in pool) config: Config,
+    pub(in pool) transaction_counters: Option<Arc<RwLock<Vec<TransactionCounter>>>>,
+
+    _d: PhantomData<D>,
+}
+
+impl<D: Deliverable> PoolBuilder<D> {
+    pub(in pool) fn new(config: Config) -> PoolBuilder<D> {
+        PoolBuilder {
+            config,
+            transaction_counters: None,
+
+            _d: PhantomData,
+        }
+    }
+
+    pub fn build(self) -> Result<Pool<D>, SpawnError> {
+        Pool::new(self)
+    }
+
+    /// Pass in an synchronized Vec<Weak<WeakCounter>> that will be populated
+    /// with transaction counters for each of the workers spawned.
+    ///
+    /// You can check that the WeakCounter is still valid by ensuring that the
+    /// Arc::strong_count on the Weak reference
+    pub fn transaction_counters(mut self, value: Arc<RwLock<Vec<TransactionCounter>>>) -> Self {
+        self.transaction_counters = Some(value);
+        self
+    }
+}

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -32,7 +32,6 @@ impl<D: Deliverable> Pool<D> {
         PoolBuilder::new(config)
     }
 
-    /// Create a new pool according to config
     pub(in pool) fn new(builder: PoolBuilder<D>) -> Result<Pool<D>, SpawnError> {
         let PoolBuilder { mut config, transaction_counters, .. } = builder;
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,3 @@
+mod rwlockext;
+
+pub use self::rwlockext::RwLockExt;

--- a/src/util/rwlockext.rs
+++ b/src/util/rwlockext.rs
@@ -1,0 +1,16 @@
+use std::sync::{RwLock, RwLockWriteGuard, RwLockReadGuard};
+
+pub trait RwLockExt<T> {
+    fn write_ignore_poison(&self) -> RwLockWriteGuard<T>;
+    fn read_ignore_poison(&self) -> RwLockReadGuard<T>;
+}
+
+impl< T> RwLockExt<T> for RwLock<T> {
+    fn write_ignore_poison(&self) -> RwLockWriteGuard<T> {
+        self.write().unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn read_ignore_poison(&self) -> RwLockReadGuard<T> {
+        self.read().unwrap_or_else(|e| e.into_inner())
+    }
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -422,6 +422,7 @@ fn transaction_counting_works() {
     loop {
         let counters = transaction_counters.try_read().unwrap();
         for counter in counters.iter() {
+            assert_eq!(counter.is_valid(), true);
             let transaction_count = counter.count();
             if transaction_count == 1 {
                 saw_transactions = true;
@@ -443,4 +444,10 @@ fn transaction_counting_works() {
     assert!(saw_transactions);
 
     pool.shutdown();
+
+    // Counters should not be valid anymore
+    let counters = transaction_counters.try_read().unwrap();
+    for counter in counters.iter() {
+        assert_eq!(counter.is_valid(), false);
+    }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -84,7 +84,7 @@ fn some_gets_single_worker() {
     let mut config = default_config();
     config.workers = 1;
 
-    let mut pool = Pool::new(config).unwrap();
+    let mut pool = Pool::builder(config).build().unwrap();
     let (tx, rx) = mpsc::channel();
 
     for _ in 0..5 {
@@ -111,7 +111,7 @@ fn ton_of_gets() {
     config.max_transactions_per_worker = 1_000;
     config.transaction_timeout = Duration::from_secs(60);
 
-    let mut pool = Pool::new(config).unwrap();
+    let mut pool = Pool::builder(config).build().unwrap();
     let (tx, rx) = mpsc::channel();
 
     for _ in 0..REQUEST_AMOUNT {
@@ -170,7 +170,7 @@ fn graceful_shutdown() {
     let mut config = default_config();
     config.workers = 2;
 
-    let mut pool = Pool::new(config).unwrap();
+    let mut pool = Pool::builder(config).build().unwrap();
     for _ in 0..txn {
         pool.request(onesignal_transaction(counter.clone())).expect("request ok");
     }
@@ -189,7 +189,7 @@ fn full_error() {
     config.workers = 3;
     config.max_transactions_per_worker = 1;
 
-    let mut pool = Pool::new(config).unwrap();
+    let mut pool = Pool::builder(config).build().unwrap();
     let (tx, rx) = mpsc::channel();
 
     // Start requests
@@ -303,7 +303,7 @@ fn keep_alive_works_as_expected() {
     let mut config = default_config();
     config.keep_alive_timeout = Duration::from_secs(3);
 
-    let mut pool = Pool::new(config).unwrap();
+    let mut pool = Pool::builder(config).build().unwrap();
     let (tx, rx) = mpsc::channel();
 
     // Start first request
@@ -343,7 +343,7 @@ fn connection_reuse_works_as_expected() {
     config.workers = 1;
     config.keep_alive_timeout = Duration::from_secs(10);
 
-    let mut pool = Pool::new(config).unwrap();
+    let mut pool = Pool::builder(config).build().unwrap();
     let (tx, rx) = mpsc::channel();
 
     // Start first request
@@ -375,7 +375,7 @@ fn timeout_works_as_expected() {
     let mut config = default_config();
     config.transaction_timeout = Duration::from_secs(2);
 
-    let mut pool = Pool::new(config).unwrap();
+    let mut pool = Pool::builder(config).build().unwrap();
     let (tx, rx) = mpsc::channel();
 
     // Start first request
@@ -392,6 +392,55 @@ fn timeout_works_as_expected() {
         DeliveryResult::Timeout { .. } => (), // ok
         res => panic!("Expected timeout!, got: {:?}", res),
     }
+
+    pool.shutdown();
+}
+
+#[test]
+fn transaction_counting_works() {
+    let _read = TEST_LOCK.read().unwrap_or_else(|e| e.into_inner());
+
+    let _ = env_logger::try_init();
+
+    let mut config = default_config();
+    config.workers = 3;
+
+    let transaction_counters = Arc::new(RwLock::new(Vec::new()));
+
+    let mut pool = Pool::builder(config)
+        .transaction_counters(transaction_counters.clone())
+        .build().unwrap();
+    let (tx, rx) = mpsc::channel();
+
+    // Start requests
+    for _ in 0..3 {
+        pool.request(onesignal_transaction(MspcDeliverable(tx.clone()))).expect("request ok");
+    }
+
+    let mut saw_transactions = false;
+    let mut received = 0;
+    loop {
+        let counters = transaction_counters.try_read().unwrap();
+        for counter in counters.iter() {
+            let transaction_count = counter.count();
+            if transaction_count == 1 {
+                saw_transactions = true;
+            }
+            assert!(transaction_count <= 1);
+        }
+
+        if let Ok(recv) = rx.try_recv() {
+            assert_successful_result(recv);
+            received += 1;
+
+            if received == 3 {
+                break;
+            }
+        }
+    }
+
+    // Make sure that we saw the counter was doing something
+    assert!(saw_transactions);
 
     pool.shutdown();
 }


### PR DESCRIPTION
Because the handle lifetimes are managed by the Pool, we use a Counter to check whether the TransactionCounter is still valid (the handle and thread still exist).