### PR TITLE
Change shutdown loop timeout to 100ms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-client-pool"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Joe Wilm <joe@jwilm.com>"]
 description = "Pooled Hyper Async Clients"
 license = "MIT OR Apache-2.0"

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -140,7 +140,7 @@ impl<D: Deliverable, C: 'static + Connect + Clone + Send + Sync> Executor<D, C> 
         // receiving transactions. This indicates a shutdown or error, which in
         // either case should cause a shutdown.
         while self.transaction_counter.count() > 0 {
-            tokio::time::delay_for(self.transaction_timeout).await;
+            tokio::time::delay_for(Duration::from_millis(100)).await;
         }
 
         info!("Executor exited.");


### PR DESCRIPTION
The transaction timeout can be set to anything - I think in production
it's in the range of 60s. This results in shutdowns taking a very long
time, if you're not lucky enough to have no transactions in flight when
the shutdown is requested. I think it is OK to use a short polling loop
here because it is only used in the shutdown process. I tried adding
polling/async ability to the raii-counter library directly, and it would
require adding instrumentation overhead to each and every add/subtract
that we do. I think this is a better solution, as it requires no
overhead during the normal runtime process.