### PR TITLE
Change HTTP span to info level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-client-pool"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Joe Wilm <joe@jwilm.com>"]
 description = "Pooled Hyper Async Clients"
 license = "MIT OR Apache-2.0"

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -9,7 +9,7 @@ use hyper::{Body, Response};
 
 use crate::deliverable::Deliverable;
 use raii_counter::Counter;
-use tracing::{debug_span, trace, Instrument};
+use tracing::{info_span, trace, Instrument};
 
 /// The result of the transaction, a message sent to the
 /// deliverable.
@@ -125,7 +125,7 @@ impl<D: Deliverable> Transaction<D> {
             span_id,
         } = self;
 
-        let outer_span = debug_span!(
+        let outer_span = info_span!(
             parent: span_id,
             "http_request",
             otel.kind = "client",


### PR DESCRIPTION
The sampling of these spans is handled by opentelemetry, we don't need
to level it down to debug.