### PR TITLE
feat: Add 'transaction-tracing' feature that can be disabled to drop http_request spans

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,22 @@
 [package]
 name = "hyper-client-pool"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Joe Wilm <joe@jwilm.com>"]
 description = "Pooled Hyper Async Clients"
 license = "MIT OR Apache-2.0"
 edition = "2018"
 
+[features]
+default = ["transaction-tracing"]
+transaction-tracing = []
+
 [dependencies]
-hyper = { version = "0.14", features = ["client", "http1", "stream", "runtime"] }
+hyper = { version = "0.14", features = [
+    "client",
+    "http1",
+    "stream",
+    "runtime",
+] }
 native-tls = "0.2"
 hyper-tls = "0.5"
 tokio-native-tls = "0.3"


### PR DESCRIPTION
In our benchmarking just creating these spans was taking 3-5% of all of our CPU during busy periods, and dropping that noticeably impacted flamegraphs.