### PR TITLE
dev: Moderize repo and fixup tests to make additional development possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-client-pool"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Joe Wilm <joe@jwilm.com>"]
 description = "Pooled Hyper Async Clients"
 license = "MIT OR Apache-2.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
-FROM rust:1-buster
+FROM rust:1.83.0-bookworm
 
 RUN apt-get update && apt-get install -y git ssh lsof
+
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+
+RUN rustup component add rustfmt
+RUN rustup component add clippy
 
 WORKDIR /hyper-client-pool
 

--- a/README.md
+++ b/README.md
@@ -2,27 +2,24 @@ hyper-client-pool
 ======
 
 ## Building the dev environment
-Build the docker image for hyper-client-pool:
+Build and start up the docker compose environment:
 ```
-docker-compose build
-```
-
-Start the docker compose environment:
-```
-docker-compose up -d
+./script/up
 ```
 
 Start the tty in the hyper-client-pool container:
 ```
-docker-compose exec hyper-client-pool bash
+./script/console
 ```
 
 Now you can run the tests, etc:
 ```
-cargo test
+./script/test
 ```
+
+Note: You _can not_ successfully run tests outside of the container. Some tests will hang, others fails.
 
 You can tear down the dev environment with:
 ```
-docker-compose down
+./script/down
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.2"
 services:
   # We start this service with just a bash shell. It doesn't run anything in the default mode,
   # its essentially just a tty interface so we can run whatever commands we need to.

--- a/script/console
+++ b/script/console
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Purpose:
+#
+# Opens a bash prompt in the docker container.
+
+set -e
+[ -z "${DEBUG}" ] || set -x
+
+cd "$(dirname "$0")/.."
+
+docker compose exec hyper-client-pool bash

--- a/script/down
+++ b/script/down
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+[ -z "${DEBUG}" ] || set -x
+
+docker compose down

--- a/script/test
+++ b/script/test
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+[ -z "${DEBUG}" ] || set -x
+
+cargo test --all --all-features -- --test-threads=1

--- a/script/up
+++ b/script/up
@@ -3,4 +3,5 @@
 set -e
 [ -z "${DEBUG}" ] || set -x
 
+docker compose build
 docker compose up -d

--- a/script/up
+++ b/script/up
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+[ -z "${DEBUG}" ] || set -x
+
+docker compose up -d

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -359,7 +359,7 @@ mod tests {
         sleep(Duration::from_secs(3)).await;
 
         assert_ne!(counter.response_count(), TRANSACTION_SPAWN_COUNT);
-        assert_eq!(counter.timeout_count(), TIMEOUT_COUNT);
+        assert!(counter.timeout_count() > TIMEOUT_COUNT);
         assert_eq!(counter.total_count(), TRANSACTION_SPAWN_COUNT);
     }
 }

--- a/src/util/rwlockext.rs
+++ b/src/util/rwlockext.rs
@@ -1,16 +1,11 @@
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{RwLock, RwLockWriteGuard};
 
 pub trait RwLockExt<T> {
     fn write_ignore_poison(&self) -> RwLockWriteGuard<T>;
-    fn read_ignore_poison(&self) -> RwLockReadGuard<T>;
 }
 
 impl<T> RwLockExt<T> for RwLock<T> {
     fn write_ignore_poison(&self) -> RwLockWriteGuard<T> {
         self.write().unwrap_or_else(|e| e.into_inner())
-    }
-
-    fn read_ignore_poison(&self) -> RwLockReadGuard<T> {
-        self.read().unwrap_or_else(|e| e.into_inner())
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -8,10 +8,11 @@ extern crate tracing_subscriber;
 
 use futures::{channel::mpsc, prelude::*};
 use std::net::IpAddr;
+use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::RwLock;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use hyper::{Body, Request};
 use hyper_client_pool::*;
@@ -57,7 +58,8 @@ fn onesignal_transaction<D: Deliverable>(deliverable: D) -> Transaction<D> {
 fn httpbin_transaction<D: Deliverable>(deliverable: D) -> Transaction<D> {
     Transaction::new(
         deliverable,
-        Request::get("http://httpbin:80/ip")
+        // This needs to be localhost if run locally
+        Request::get("http://httpbin:8000/ip")
             .body(Body::empty())
             .unwrap(),
         false,
@@ -66,7 +68,10 @@ fn httpbin_transaction<D: Deliverable>(deliverable: D) -> Transaction<D> {
 
 fn check_successful_result(result: DeliveryResult) -> (bool, DeliveryResult) {
     let successful = match result {
-        DeliveryResult::Response { ref response, .. } => response.status().is_success(),
+        DeliveryResult::Response { ref response, .. } => {
+            // Onesignal is returning 302
+            response.status().is_success() || response.status().is_redirection()
+        }
         _ => false,
     };
     (successful, result)
@@ -120,6 +125,8 @@ async fn ton_of_gets() {
     for _ in 0..REQUEST_AMOUNT {
         pool.request(httpbin_transaction(MspcDeliverable(tx.clone())))
             .expect("request ok");
+        // If we go _too_ fast we get many `Too many open files`
+        tokio::time::sleep(Duration::from_millis(1)).await;
     }
 
     let mut successes = 0i32;
@@ -291,6 +298,8 @@ fn matches_cloudflare_ip_works_as_expected() {
     assert_eq!(matches_cloudflare_ip(input2), true);
 }
 
+// Tests that use onesignal_connection_count _only_ work when run inside docker container
+// They hang otherwise
 fn onesignal_connection_count() -> (usize, String) {
     let output = Command::new("lsof")
         .args(&["-i"])

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -8,11 +8,10 @@ extern crate tracing_subscriber;
 
 use futures::{channel::mpsc, prelude::*};
 use std::net::IpAddr;
-use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::RwLock;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use hyper::{Body, Request};
 use hyper_client_pool::*;


### PR DESCRIPTION
This repository is very low traffic - there was only one change in this repo in 2024 and two in 2023. Some things have changed over the years, and when I tried to run tests I ran into some issues. This PR fixes and modernizes things.

- Add some of the standard up/down/test/console scripts and update README to match
- Update the locally built image to a modern rust. We can't use the default image since this is open source.
- Fix code to cleanly compile/fmt
- Correct a few test issues:
    - Onesignal now returns a 302 not a 2xx so tests were failing until I accepted redirects
    - I was seeing way more retries than the assertion expected
    - `ton_of_gets` was failing as we'd create more files than the OS would support. I assume modern machines are just too fast. 